### PR TITLE
Include xxh3.h in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst
 include CHANGELOG.rst
 include LICENSE
+include deps/xxhash/xxh3.h
 include deps/xxhash/xxhash.h
 include deps/xxhash/xxhash.c
 include deps/xxhash/LICENSE


### PR DESCRIPTION
The source distribution `xxhash-1.4.0.tar.gz` on [PyPI](https://pypi.org/project/xxhash/#files) is missing the file `xxh3.h` such that building from source fails:
```
deps/xxhash/xxhash.c(1115): fatal error C1083: Cannot open include file: 'xxh3.h': No such file or directory
```