### PR TITLE
ci: add 3.13t to matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.9', 'pypy3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', 'pypy3.9', 'pypy3.10']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add initial support for testing against free-threaded Python builds
