### PR TITLE
Declare PyInit__xxhash function as module entry point

### DIFF
--- a/src/_xxhash.c
+++ b/src/_xxhash.c
@@ -1638,7 +1638,7 @@ static struct PyModuleDef moduledef = {
 
 #define INITERROR return NULL
 
-PyObject *PyInit__xxhash(void)
+PyMODINIT_FUNC PyInit__xxhash(void)
 {
     PyObject *module;
 


### PR DESCRIPTION
Windows expects exported symbols to be declared as such - with `__declspec(dllexport)`. The declaration is missing for the `PyInit__xxhash()` function.

This declaration is provided automatically, if init function's return type is set to `PyMODINIT_FUNC`. `PyMODINIT_FUNC` macro indicates the function is a module entry point and provides secondary declarations for the linker to export the object, if needed.

Resolves [issue 97](https://github.com/ifduyue/python-xxhash/issues/97)