### PR TITLE
Declare extension module to be free-threading compatible

### DIFF
--- a/src/_xxhash.c
+++ b/src/_xxhash.c
@@ -1684,5 +1684,9 @@ PyMODINIT_FUNC PyInit__xxhash(void)
     /* version */
     PyModule_AddStringConstant(module, "XXHASH_VERSION", VALUE_TO_STRING(XXHASH_VERSION));
 
+#ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
     return module;
 }


### PR DESCRIPTION
This is a follow-up to gh-94. The full test suite passes under thread-parallel testing with `pytest-run-parallel` and ThreadSanitizer.  xxHash is thread-safe (https://github.com/Cyan4973/xxHash/issues/133), and in `src/_xxhash.c` the update calls release the GIL already (`Py_BEGIN_ALLOW_THREADS`), so all looks good.