### PR TITLE
ci: enable free-threaded (cp313t) wheel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,12 +36,20 @@ jobs:
         uses: docker/setup-qemu-action@v3
         if: runner.os == 'Linux'
 
+      - name: Enable PyPy and free-threading
+        run: |
+          echo "CIBW_ENABLE=pypy cpython-freethreading" >> "$GITHUB_ENV"
+
+      - name: Enable CPython pre-release wheels
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+            echo "CIBW_ENABLE=$CIBW_ENABLE cpython-prerelease" >> "$GITHUB_ENV"
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ARCHS: "${{ matrix.archs }}"
           CIBW_BUILD: "${{ matrix.build && '*-' || ''}}${{ matrix.build }}*"
-          CIBW_PRERELEASE_PYTHONS: "${{ !startsWith(github.ref, 'refs/tags/v') }}"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This addresses part of gh-101.

The reason for the separate job steps and passing the `CIBW_ENABLE` environment variable between steps, which was slightly fiddly to get right, is that pre-release CPython were built conditionally (`!startsWith(github.ref, 'refs/tags/v')`), and this was the only way to keep that logic unchanged while moving to `CIBW_ENABLE`.

This change also fixes some deprecation warnings that `cibuildwheel` was emitting (see for example the "Build wheels" step output of [this recent CI log](https://github.com/ifduyue/python-xxhash/actions/runs/14884258836/job/41799529232)):
```
Warning: free-threaded-support and prerelease-pythons should be specified by enable instead

Warning: PyPy builds will be disabled by default in version 3. Enabling PyPy builds should be specified by enable
```