### PR TITLE
ci: speed up GitHub Actions by upgrading runners and adding uv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "${{ matrix.os }}${{ (startsWith(matrix.archs, 'aarch64') || startsWith(matrix.archs, 'armv7l')) && '-arm' || '' }}"
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
         archs: ["x86_64, i686", "aarch64", "ppc64le", "s390x", "riscv64", "armv7l"]
         build: ["manylinux", "musllinux"]
         platform: ["auto"]
@@ -17,7 +17,7 @@ jobs:
             archs: "AMD64"
           - os: windows-2022
             archs: "x86"
-          - os: windows-2022
+          - os: windows-11-arm
             archs: "ARM64"
           - os: macos-15-intel
             archs: "x86_64"
@@ -48,6 +48,9 @@ jobs:
         uses: docker/setup-qemu-action@v4
         if: runner.os == 'Linux'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
       - name: Enable PyPy and free-threading
         shell: bash
         run: |
@@ -74,7 +77,7 @@ jobs:
 
   build_sdist:
     name: Build sdist
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ['3.10']
@@ -104,7 +107,7 @@ jobs:
   upload_test_pypi:
     name: Upload to Test PyPI
     needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push' && github.repository == 'ifduyue/python-xxhash' && !startsWith(github.ref, 'refs/tags/v')
     permissions:
       id-token: write
@@ -119,7 +122,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
           repository-url: https://test.pypi.org/legacy/
@@ -127,7 +130,7 @@ jobs:
   upload_pypi:
     name: Upload to PyPI
     needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push' && github.repository == 'ifduyue/python-xxhash' && startsWith(github.ref, 'refs/tags/v')
     environment:
       name: pypi
@@ -143,6 +146,6 @@ jobs:
 
       - name: Upload to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   codspeed:
     name: Run benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -19,6 +19,7 @@ jobs:
           - "3.14t"
           - "pypy3.9"
           - "pypy3.10"
+          - "pypy3.11"
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [build-system]
 requires = ["setuptools>=45"]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build-frontend = "build[uv]"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux_{ppc64le,riscv64,s390x}"
+build-frontend = "build"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-ios*"
+build-frontend = "build"


### PR DESCRIPTION
- Upgrade ubuntu-22.04 -> ubuntu-24.04 (faster CPU/network)
- Upgrade windows-2022 ARM64 -> windows-11-arm (correct runner)
- Add astral-sh/setup-uv for cibuildwheel to use uv internally
- Add cibuildwheel build-frontend build[uv] in pyproject.toml with overrides for musllinux exotic archs and iOS
- Switch pypa/gh-action-pypi-publish to release/v1 tag
- Add pypy3.11 to test matrix