### PR TITLE
Register the “benchmark” pytest mark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ implicit_reexport = false
 strict_equality = true
 pretty = true
 error_summary = false
+
+[tool.pytest.ini_options]
+markers = [
+    "benchmark",
+]


### PR DESCRIPTION
Avoids warnings of the form:

```
PytestUnknownMarkWarning: Unknown pytest.mark.benchmark - is this a
typo?  You can register custom marks to avoid this warning - for
details, see https://docs.pytest.org/en/stable/how-to/mark.html
```