### PR TITLE
ci: upgrade cibuildwheel and CodSpeed action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS: "${{ matrix.archs }}"
           CIBW_BUILD: "${{ matrix.build && '*-' || ''}}${{ matrix.build }}*"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -36,7 +36,7 @@ jobs:
         run: python setup.py build_ext --inplace
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@88472375d0a4572cf70a9f1fe3a4e0ab8da1b924 # v5.0.1
+        uses: CodSpeedHQ/action@4296e51e7041e24dadb86d1d6e8b9320d223dbe8 # v5.0.3
         with:
           mode: simulation
           run: pytest tests/test_benchmark.py --codspeed


### PR DESCRIPTION
## Summary

Upgrade the two GitHub Actions that were not yet at their latest stable release, keeping the existing convention of pinning to full commit SHAs with the specific version as a comment.

## Changes

- `pypa/cibuildwheel` v4.1.1 → **v4.2.0** (`1828c10…`)
- `CodSpeedHQ/action` v5.0.1 → **v5.0.3** (`4296e51…`)

All other actions in `.github/workflows/` were verified to already be at their latest stable version and are left unchanged.