### PR TITLE
Prepare 4.0.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,21 @@ CHANGELOG
 NEXT
 ~~~~~~~~~~~~~~~~~
 
-- Drop support for Python 3.8
+- **Breaking change**: Drop support for Python 3.8, require Python >= 3.9
+- **Breaking change**: Remove deprecated ``xxhash.VERSION_TUPLE``
+- Upgrade xxHash from v0.8.2 to v0.8.3. Note: on GCC/Clang source builds
+  that target AVX2 (e.g. ``-march=x86-64-v3``), upstream v0.8.3
+  autovectorizes ``XXH64_update()`` and makes the xxh64 streaming path
+  about 2x slower. The shipped wheels are built for baseline x86-64 and
+  are unaffected. Source builds can work around it by adding
+  ``-fno-tree-vectorize`` to the compiler flags.
+- Add per-object locking for thread safety, with sub-interpreter and
+  free-threaded (no-GIL) Python support
+- Build pyodide wasm32 wheels
+- Add s390x big-endian test job
+- Add Python 3.15 classifier
+- CI: shard the PyPI upload into parallel groups and create the GitHub
+  Release automatically
 
 v3.8.1 2026-07-06
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -87,9 +87,9 @@ the module properties ``VERSION`` AND ``XXHASH_VERSION`` respectively.
 
     >>> import xxhash
     >>> xxhash.VERSION
-    '2.0.0'
+    '4.0.0'
     >>> xxhash.XXHASH_VERSION
-    '0.8.0'
+    '0.8.3'
 
 This module is hashlib-compliant, which means you can use it in the same way as ``hashlib.md5``.
 

--- a/README.rst
+++ b/README.rst
@@ -251,6 +251,27 @@ And aliases:
     | xxh128_intdigest = xxh3_128_intdigest
     | xxh128_hexdigest = xxh3_128_hexdigest
 
+Thread safety
+-------------
+
+Streaming hash objects (``xxh32``, ``xxh64``, ``xxh3_64``, ``xxh3_128`` /
+``xxh128``) are thread-safe: each object carries a per-object lock that
+serializes access to its internal xxHash state, so concurrent ``update()``,
+``digest()``, ``copy()``, and ``reset()`` calls on the same object never
+corrupt state or crash.
+
+One-shot functions (``xxh32_digest``, ``xxh64_hexdigest``, ``xxh3_128_digest``,
+etc.) are stateless and always safe to call concurrently.
+
+On Python 3.13+ the lock is always active. On Python 3.9-3.12 the lock is
+created on the first ``update()`` of 64KB or more; smaller operations never
+release the GIL, so they are serialized by the GIL itself.
+
+Sharing a streaming hash object across threads is still discouraged: even
+with locking, the order in which concurrent updates are applied (and hence
+the final digest) is nondeterministic. Prefer one-shot functions or one hash
+object per thread.
+
 Caveats
 -------
 

--- a/xxhash/__init__.py
+++ b/xxhash/__init__.py
@@ -18,7 +18,7 @@ from ._xxhash import (
     XXHASH_VERSION,
 )
 
-from .version import VERSION, VERSION_TUPLE
+from .version import VERSION
 
 
 xxh128 = xxh3_128
@@ -59,7 +59,6 @@ __all__ = [
     "xxh128_intdigest",
     "xxh128_hexdigest",
     "VERSION",
-    "VERSION_TUPLE",
     "XXHASH_VERSION",
     "algorithms_available",
     "algorithms_guaranteed",

--- a/xxhash/__init__.pyi
+++ b/xxhash/__init__.pyi
@@ -8,8 +8,6 @@ _DataType = _Buffer
 
 VERSION: str
 XXHASH_VERSION: str
-#: Deprecated, will be removed in the next major release
-VERSION_TUPLE: tuple[int, ...]
 
 algorithms_available: set[str]
 algorithms_guaranteed: set[str]
@@ -36,7 +34,6 @@ __all__: list[str] = [
     "xxh128_intdigest",
     "xxh128_hexdigest",
     "VERSION",
-    "VERSION_TUPLE",
     "XXHASH_VERSION",
     "algorithms_available",
     "algorithms_guaranteed",

--- a/xxhash/version.py
+++ b/xxhash/version.py
@@ -1,3 +1,1 @@
 VERSION = "3.8.0.dev9"
-#: Deprecated, will be removed in the next major release
-VERSION_TUPLE = (3, 8, 0)

--- a/xxhash/version.py
+++ b/xxhash/version.py
@@ -1,1 +1,1 @@
-VERSION = "3.8.0.dev9"
+VERSION = "4.0.0.dev0"


### PR DESCRIPTION
## Summary

Release preparation for 4.0.0, the next major version.

## Changes

- **Breaking**: remove deprecated `xxhash.VERSION_TUPLE` (deprecated in v3.6.0, scheduled for removal in the next major release)
- Bump version to `4.0.0.dev0`
- Document the thread-safety model and update the README version example
- Update the changelog for 4.0.0: drop Python 3.8, remove `VERSION_TUPLE`, upgrade xxHash to v0.8.3 (with a note about the upstream `XXH64_update` autovectorization regression on AVX2-targeted GCC/Clang builds; shipped wheels are unaffected), per-object locking for sub-interpreter and free-threaded Python support, pyodide wasm32 wheels, s390x test job, Python 3.15 classifier, and the sharded PyPI upload

## Testing

- Full test suite passes (132 tests; free-threading/sub-interpreter cases skip on regular CPython)