### PR TITLE
Bump version to 4.0.0.dev5

### DIFF
--- a/tests/test_fastcall.py
+++ b/tests/test_fastcall.py
@@ -51,19 +51,19 @@ class TestFastcallNormal(unittest.TestCase):
 
     def test_positional_seed_xxh32(self):
         for s in self.seeds_32:
-            self._check('xxh32', self.data, seed=s)
+            self._check('xxh32', self.data, s)
 
     def test_positional_seed_xxh64(self):
         for s in self.seeds_64:
-            self._check('xxh64', self.data, seed=s)
+            self._check('xxh64', self.data, s)
 
     def test_positional_seed_xxh3_64(self):
         for s in self.seeds_64:
-            self._check('xxh3_64', self.data, seed=s)
+            self._check('xxh3_64', self.data, s)
 
     def test_positional_seed_xxh3_128(self):
         for s in self.seeds_64:
-            self._check('xxh3_128', self.data, seed=s)
+            self._check('xxh3_128', self.data, s)
 
     # ── keyword input ─────────────────────────────────────────────
 

--- a/xxhash/version.py
+++ b/xxhash/version.py
@@ -1,1 +1,1 @@
-VERSION = "4.0.0.dev0"
+VERSION = "4.0.0.dev5"


### PR DESCRIPTION
## Summary

Bump the development version to `4.0.0.dev5` and fix the positional-seed tests.

## Changes

- Bump version to `4.0.0.dev5`
- `tests/test_fastcall.py`: `test_positional_seed_*` now pass the seed positionally instead of as a keyword, so the positional seed path (`xxh32(data, 42)` and the corresponding one-shot functions) is actually exercised instead of duplicating `test_keyword_seed_*`

## Testing

- `python3 -m unittest tests.test_fastcall` passes (35 tests)