### PR TITLE
Add _xxhash module docstring

### DIFF
--- a/src/_xxhash.c
+++ b/src/_xxhash.c
@@ -2246,7 +2246,10 @@ static PyMethodDef methods[] = {
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     "_xxhash",
-    NULL,
+    "Low-level C extension for the xxhash package.\n"
+    "\n"
+    "Provides the XXH32, XXH64, XXH3_64, and XXH3_128 hash types plus\n"
+    "their one-shot digest(), intdigest(), and hexdigest() functions.",
     0,
     methods,
     slots,

--- a/xxhash/version.py
+++ b/xxhash/version.py
@@ -1,1 +1,1 @@
-VERSION = "4.0.0"
+VERSION = "4.0.1.dev0"


### PR DESCRIPTION
Add a module docstring to the `_xxhash` C extension so `help(xxhash._xxhash)` is no longer empty.